### PR TITLE
array_key_existsのwaring修正

### DIFF
--- a/TextDiff.php
+++ b/TextDiff.php
@@ -149,7 +149,7 @@ class TextDiff
                     ++$count;
                 } else {
                     $before = $count -1;
-                    if(array_key_exists($before, $words) && !array_key_exists('source', $words[$before])) {
+                    if(array_key_exists($before, $words) && is_array($words[$before]) && !array_key_exists('source', $words[$before])) {
                         $words[$before] .= $val;
                     } else {
                         $words[] = $val;


### PR DESCRIPTION
#3
１行に異なる単語が2つ以上あった場合にwarningになる
を修正しました
該当のarray_key_existsの前にis_array判定を追加しています